### PR TITLE
Use multiprocessing

### DIFF
--- a/transcribe_audio.py
+++ b/transcribe_audio.py
@@ -1,6 +1,71 @@
+import subprocess
+import os
+from multiprocessing import Pool, cpu_count
+
 import whisper
 
-def transcribe_audio(audio_path):
+# Global model for multiprocessing
+model = None
+
+def init_model():
+    global model
     model = whisper.load_model("small")
-    result = model.transcribe(audio_path, word_timestamps=True)
-    return result['segments']
+
+#Split the audio into 30 second increments
+
+def split_audio(input_audio_path, chunk_duration_sec=60, output_dir="audio_chunks"):
+    os.makedirs(output_dir, exist_ok=True)
+
+    output_template = os.path.join(output_dir, "chunk_%03d.wav")
+
+    command = [
+        "ffmpeg",
+        "-i", input_audio_path,
+        "-f", "segment",
+        "-segment_time", str(chunk_duration_sec),
+        "-c", "copy",
+        output_template,
+        "-y"
+    ]
+
+    subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return sorted([
+        os.path.join(output_dir, f) for f in os.listdir(output_dir) if f.endswith(".wav")
+        ])
+
+#Transcribe the audio
+
+def transcribe_audio(args):
+    global model
+    index, filepath, chunk_duration = args
+    offset = index * chunk_duration
+
+    result = model.transcribe(filepath, word_timestamps=True, fp16=False)
+
+    for segment in result["segments"]:
+        segment["start"] += offset
+        segment["end"] += offset
+        # if "words" in segment:
+        #     for word in segment["words"]:
+        #         word["start"] += offset
+        #         word["end"] += offset
+
+    return result["segments"]
+
+def grab_audio_segments(input_audio_path):
+
+    audio_chunks = split_audio(input_audio_path)
+
+    args = [(i, path, 60) for i, path in enumerate(audio_chunks)]
+
+    with Pool(processes=6, initializer=init_model) as pool:
+        all_segments = pool.map(transcribe_audio, args)
+
+    # Flatten and print result
+    return [seg for chunk in all_segments for seg in chunk]
+
+
+    # def transcribe_audio(audio_path):
+    #     model = whisper.load_model("small")
+    #     result = model.transcribe(audio_path, word_timestamps=True)
+    #     return result['segments']

--- a/video_word_counter.py
+++ b/video_word_counter.py
@@ -1,7 +1,7 @@
 import os
 
 from extract_audio import extract_audio_ffmpeg
-from transcribe_audio import transcribe_audio
+from transcribe_audio import grab_audio_segments
 from word_counter import get_word_counts
 
 import pandas as pd
@@ -18,7 +18,7 @@ def process_video(video_file):
     with open(video_path, "wb") as f:
         f.write(video_file.read())
     audio_path = extract_audio_ffmpeg(video_path)
-    segments = transcribe_audio(audio_path)
+    segments = grab_audio_segments(audio_path)
     counter, word_times = get_word_counts(segments)
     return video_path, counter, word_times
 
@@ -35,6 +35,8 @@ if st.session_state.get("processed", False):
     counter = st.session_state.counter
     word_times = st.session_state.word_times
     video_path = st.session_state.video_path
+    # segments = st.session_state.segments
+    # st.text(segments)
 
     st.subheader("Word Frequencies")
     df = pd.DataFrame.from_dict(dict(counter), 


### PR DESCRIPTION
### Description

Rather than pass the entire video to Whisper, I decided to break the video's audio into 60 second segments, and use the multithreading Pool function to send multiple audio segments at the same time, making the app much more efficient for larger videos

### Changes

1. Change `transcribe_audio.py` to use `multiprocessing`
2. Update `video_word_counter.py` to take the outputs of the updated `transcribe_audio.py`